### PR TITLE
Build updates for Visual Studio 2017

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -40,17 +40,18 @@ set (AVRO_VERSION_MINOR "0")
 project (Avro-cpp)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
 
-add_definitions(-std=c++11 -fPIC)
-
 if (WIN32 AND NOT CYGWIN AND NOT MSYS)
-add_definitions (/EHa)
-add_definitions (
-    -DBOOST_REGEX_DYN_LINK
-    -DBOOST_FILESYSTEM_DYN_LINK
-    -DBOOST_SYSTEM_DYN_LINK
-    -DBOOST_IOSTREAMS_DYN_LINK
-    -DBOOST_PROGRAM_OPTIONS_DYN_LINK
-    -DBOOST_ALL_NO_LIB)
+    add_definitions (/EHa)
+    add_definitions (
+        -DNOMINMAX
+        -DBOOST_REGEX_DYN_LINK
+        -DBOOST_FILESYSTEM_DYN_LINK
+        -DBOOST_SYSTEM_DYN_LINK
+        -DBOOST_IOSTREAMS_DYN_LINK
+        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+        -DBOOST_ALL_NO_LIB)
+else()
+    add_definitions(-std=c++11 -fPIC)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)

--- a/lang/c++/api/Config.hh
+++ b/lang/c++/api/Config.hh
@@ -31,6 +31,10 @@
 # define AVRO_DECL __declspec(dllimport)
 #endif  // AVRO_SOURCE
 #endif  // AVRO_DYN_LINK
+
+#include <intsafe.h>
+typedef SSIZE_T ssize_t;
+
 #endif  // _WIN32
 
 #ifndef AVRO_DECL

--- a/lang/c++/impl/ValidSchema.cc
+++ b/lang/c++/impl/ValidSchema.cc
@@ -17,6 +17,7 @@
  */
 
 #include <boost/format.hpp>
+#include <cctype>
 #include <sstream>
 
 #include "ValidSchema.hh"

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -121,6 +121,23 @@ public:
 
 static string decorate(const avro::Name& name)
 {
+    static const char * cppReservedWords[] = {
+        "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break",
+        "case", "catch", "char", "char8_t", "char16_t", "char32_t", "class", "compl", "concept",
+        "const", "consteval", "constexpr", "const_cast", "continue", "co_await", "co_return",
+        "co_yield", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else",
+        "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if",
+        "import", "inline", "int", "long", "module", "mutable", "namespace", "new", "noexcept", "not",
+        "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "reflexpr",
+        "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof", "static",
+        "static_assert", "static_cast", "struct", "switch", "synchronized", "template", "this",
+        "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned",
+        "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
+    };
+
+    for (size_t i = 0; i < sizeof(cppReservedWords)/sizeof(cppReservedWords[0]); i++)
+        if (strcmp(name.simpleName().c_str(), cppReservedWords[i]) == 0)
+            return name.simpleName() + '_';
     return name.simpleName();
 }
 
@@ -132,11 +149,12 @@ string CodeGen::fullname(const string& name) const
 string CodeGen::generateEnumType(const NodePtr& n)
 {
     string s = decorate(n->name());
-    os_ << "enum " << s << " {\n";
+    os_ << "enum class " << s << ": unsigned {\n";
     size_t c = n->names();
     for (size_t i = 0; i < c; ++i) {
-        os_ << "    " << n->nameAt(i) << ",\n";
+        os_ << "    " << decorate(n->nameAt(i)) << ",\n";
     }
+    os_ << "    MAX = " << (c - 1) << "\n";
     os_ << "};\n\n";
     return s;
 }
@@ -503,35 +521,20 @@ void CodeGen::generateEnumTraits(const NodePtr& n)
 {
 	string dname = decorate(n->name());
 	string fn = fullname(dname);
-	size_t c = n->names();
-	string first;
-	string last;
-	if (!ns_.empty())
-	{
-		first = ns_;
-		first += "::";
-		first += n->nameAt(0);
 
-		last = ns_;
-		last += "::";
-		last += n->nameAt(c-1);
-	} else {
-		first = n->nameAt(0);
-		last = n->nameAt(c-1);
-	}
 	os_ << "template<> struct codec_traits<" << fn << "> {\n"
 		<< "    static void encode(Encoder& e, " << fn << " v) {\n"
-		<< "		if (v < "  << first << " || v > " << last << ")\n"
+		<< "		if (v > " << fn << "::MAX)\n"
 		<< "		{\n"
 		<< "			std::ostringstream error;\n"
-		<< "			error << \"enum value \" << v << \" is out of bound for " << fn << " and cannot be encoded\";\n"
+		<< "			error << \"enum value \" << static_cast<unsigned>(v) << \" is out of bound for " << fn << " and cannot be encoded\";\n"
 		<< "			throw avro::Exception(error.str());\n"
 		<< "		}\n"
-		<< "        e.encodeEnum(v);\n"
+		<< "        e.encodeEnum(static_cast<size_t>(v));\n"
 		<< "    }\n"
 		<< "    static void decode(Decoder& d, " << fn << "& v) {\n"
 		<< "		size_t index = d.decodeEnum();\n"
-		<< "		if (index > " << last << ")\n"
+		<< "		if (index > static_cast<size_t>(" << fn << "::MAX))\n"
 		<< "		{\n"
 		<< "			std::ostringstream error;\n"
 		<< "			error << \"enum value \" << index << \" is out of bound for " << fn << " and cannot be decoded\";\n"

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -80,7 +80,7 @@ void setRecord(testgen::RootRecord &myRecord)
     myRecord.myarray.push_back(3434.9);
     myRecord.myarray.push_back(7343.9);
     myRecord.myarray.push_back(-63445.9);
-    myRecord.myenum = testgen::one;
+    myRecord.myenum = testgen::ExampleEnum::one;
 
     map<string, int32_t> m;
     m["one"] = 1;


### PR DESCRIPTION
Fixes to build and work with `vcpkg` and VS2017.

* Add `-DNOMINMAX` to get rid of compile errors due to macros for `min()` and `max()` being defined in `ntdef.h`
* Define `ssize_t`
* Add `#include <cctype>` to fix compile errors.
* Updated the C++ code generation to recognize C++ keywords and add a trailing underscore to any symbol names that would otherwise clash with a keyword.
* Use C++11 scoped enumeration types for better type safety, and to avoid errors in the generated code. Without it, two Avro enums that had the same symbol would clash and the generated code would fail to compile.